### PR TITLE
Added jwst model to pn_localzodi.py

### DIFF
--- a/lifesim/instrument/instrument.py
+++ b/lifesim/instrument/instrument.py
@@ -56,6 +56,9 @@ class Instrument(InstrumentModule):
     data.inst['radius_map'] : np.ndarray
         A map used for speeding up calculations. Contains the distance of a pixel
         from the center of the detector in [pix].
+    data.inst['jwst_localzodi'] : np.ndarray
+        Pre-calculated localzodi background for whole sky, at integer wavelengths (3-20 microns)
+        in [photons/(sr m s)]. E.g. [k, :, :] provides skymap for wavelength of k+3 microns
     """
 
     def __init__(self,
@@ -117,6 +120,9 @@ class Instrument(InstrumentModule):
         r_square_map = ((x_map - (self.data.options.other['image_size'] - 1) / 2) ** 2
                         + (y_map - (self.data.options.other['image_size'] - 1) / 2) ** 2)
         self.data.inst['radius_map'] = np.sqrt(r_square_map)
+        
+        # load localzodi background data for calculations with jwst model
+        self.data.inst['jwst_localzodi'] = np.load('JWST_localzodi.npy')
 
     def get_wl_bins_const_spec_res(self):
         """

--- a/lifesim/util/options.py
+++ b/lifesim/util/options.py
@@ -40,8 +40,8 @@ class Options(object):
             - ``'n_plugins'`` : Number of sockets the instrument class will feature.
     models : dict
         Options concerning different models used in the simulation. They are
-            - ``'localzodi'`` : Model for the localzodi, possible options are ``'glasse'`` and
-              ``'darwinsim'``
+            - ``'localzodi'`` : Model for the localzodi, possible options are ``'glasse'``,
+              ``'darwinsim'`` and ``'jwst'``.
             - ``'habitable'`` : Model used for calculating the habitable zone, possible options are
               ``'MS'`` and ``'POST_MS'``
     optimization : dict


### PR DESCRIPTION
-Added file JWST_localzodi.npy, contains localzodi background values calculated by JWST Backgrounds Tool in [photons/(sr m s)]

-Due to being unsure whether to put the file in the instrument or util folder, it is currently placed in the gui folder, to avoid changing directory

-Added the possibility to set options.models['localzodi'] to 'jwst' in order to read data from the new model

-Updated comments to mention jwst model as well